### PR TITLE
Replace deprecated redirect_to :back with redirect_back_or_to (Rails 7)

### DIFF
--- a/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
+++ b/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
@@ -6,7 +6,7 @@ module RocketJobMissionControl
 
     rescue_from AccessGranted::AccessDenied do |exception|
       raise exception if Rails.env.development? || Rails.env.test?
-      redirect_to :back, alert: "Access not authorized."
+      redirect_back_or_to dirmon_entries_path, alert: "Access not authorized."
     end
 
     def index

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -332,7 +332,7 @@ module RocketJobMissionControl
 
       raise exception if Rails.env.development? || Rails.env.test?
 
-      redirect_to :back
+      redirect_back_or_to jobs_path
     end
 
     def render_datatable(jobs, description, columns, sort_order)

--- a/app/controllers/rocket_job_mission_control/servers_controller.rb
+++ b/app/controllers/rocket_job_mission_control/servers_controller.rb
@@ -13,7 +13,7 @@ module RocketJobMissionControl
     rescue_from AccessGranted::AccessDenied do |exception|
       raise exception if Rails.env.development? || Rails.env.test?
 
-      redirect_to :back, alert: "Access not authorized."
+      redirect_back_or_to servers_path, alert: "Access not authorized."
     end
 
     def index


### PR DESCRIPTION
## Summary

- Replace all `redirect_to :back` calls with `redirect_back_or_to` across three controllers (`JobsController`, `ServersController`, `DirmonEntriesController`)
- `redirect_to :back` was removed in Rails 5.1+ and raises `undefined method 'back_url'` on Rails 7, causing 500 errors on the RJMC scheduled jobs page when any exception is caught
- `redirect_back_or_to` is the idiomatic Rails 7 replacement — it tries the HTTP referer first, then falls back to the provided path

## Files Changed

- `app/controllers/rocket_job_mission_control/jobs_controller.rb` — `error_occurred` method
- `app/controllers/rocket_job_mission_control/servers_controller.rb` — `AccessDenied` rescue
- `app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb` — `AccessDenied` rescue

## Test Plan

- [ ] Verify RJMC scheduled jobs page loads without Ajax errors after deploy
- [ ] Verify servers and dirmon entries pages handle access denied gracefully